### PR TITLE
feat(links): Support for additionalLinks variable

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -38,6 +38,8 @@ params:
     dataLookup: faucetUrl
   - name: "JSON RPC"
     dataLookup: rpcUrl
+
+  # additionalLinks:
   # - name: "Launchpad"
   #   url: "https://kiln.launchpad.ethereum.org"
 

--- a/layouts/shortcodes/link_table.html
+++ b/layouts/shortcodes/link_table.html
@@ -24,5 +24,19 @@
       </td>
     </tr>
   {{ end }}
+  {{ range $.Page.Site.Params.additionalLinks }}
+    <tr>
+      <td>
+        {{ .name }}
+      </td>
+      <td>
+        {{ if .url }}
+          <a href="{{ .url }}">{{ .url }}</a>
+        {{ else }}
+          <a href="{{ index $.Page.Site.Params.ethereum .dataLookup }}">{{ index $.Page.Site.Params.ethereum .dataLookup }}</a>
+        {{ end }}
+      </td>
+    </tr>
+  {{ end }}
   </tbody>
 </table>


### PR DESCRIPTION
Unfortunately Hugo didn't want to `union` the two arrays (of `links` and `additionalLinks`) because they're arrays containing different types. Took to quick way out and copy/pasted for now.